### PR TITLE
Fix avatar selector

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
  
   "name": "Jira Black",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Turn your Jira Cloud to Black",
   "icons": {
     "128": "icon128.png"

--- a/style.css
+++ b/style.css
@@ -5,9 +5,8 @@ html {
 body {
     background: white;
 }
-span[role="img"] {
-    filter: invert(100%) hue-rotate(180deg) brightness(105%) contrast(105%);
-}
+[data-test-id*="profile"] span:empty,
+span[role="img"],
 img, svg, iframe, .emoji-common-emoji-sprite {
     filter: invert(100%) hue-rotate(180deg) brightness(105%) contrast(105%);
 }


### PR DESCRIPTION
Seems Jira components are slightly different, applying images not by a semantic image, but a `span` with `background-image` property:
![image](https://user-images.githubusercontent.com/2922954/162843788-708d98da-84ec-4e55-8f99-5c9f1609254f.png)

So, I changed the selector for a broader match.

Fixes https://github.com/jbronssin/jira-black/issues/1