### PR TITLE
Add css rule to fix inverted account dropdown profile picture

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@ body {
     background: white;
 }
 #ak-side-navigation [data-navheader*="true"] span:empty,
+.atlaskit-portal [data-placement="bottom-end"] span:empty,
 [aria-label*="profile"] span:empty,
 [data-testid*="profile"] span:empty,
 [data-test-id*="profile"] span:empty,


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/13386164/188210635-509ecf07-bb20-44a8-ad79-542ead3ceb15.png)

### After
![image](https://user-images.githubusercontent.com/13386164/188210708-79cdd89d-6d46-45ac-96c6-569807a3f389.png)


Fixes #8 