### PR TITLE
Added bitbucket and the admin section of atlassian

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,13 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://*.atlassian.net/*", "https://*.herocoders.com/issue/*"],
+      "matches": [
+        "https://*.atlassian.net/*", 
+        "https://*.herocoders.com/issue/*", 
+        "https://bitbucket.org/*", 
+        "https://id.atlassian.com/*", 
+        "https://admin.atlassian.com/*"
+      ],
       "exclude_matches":["https://*.atlassian.net/wiki/*"],
       "js": ["script.js"],
       "css": ["style.css"],


### PR DESCRIPTION
I tested every page I could think of and everything seems to look fine. Love the plugin for Jira but was wanting a solution for Bitbucket Cloud (as only the Server/Enterprise version has dark mode settings). I also added in the admin/account settings urls as they also seem to work as intended.